### PR TITLE
Build AAR file with the plugin version in its name

### DIFF
--- a/GodotGooglePlayBilling.gdap
+++ b/GodotGooglePlayBilling.gdap
@@ -2,7 +2,7 @@
 
 name="GodotGooglePlayBilling"
 binary_type="local"
-binary="GodotGooglePlayBilling.release.aar"
+binary="GodotGooglePlayBilling.1.0.0.release.aar"
 
 [dependencies]
 remote=["com.android.billingclient:billing:3.0.0"]

--- a/godot-google-play-billing/build.gradle
+++ b/godot-google-play-billing/build.gradle
@@ -2,21 +2,25 @@ plugins {
     id 'com.android.library'
 }
 
+ext.pluginVersionCode = 1
+ext.pluginVersionName = "1.0.0"
+
 android {
     compileSdkVersion 29
     buildToolsVersion "29.0.3"
 
     defaultConfig {
         minSdkVersion 18
-        targetSdkVersion 29
+        targetSdkVersion 29 
+        versionCode pluginVersionCode
+        versionName pluginVersionName
     }
 
     libraryVariants.all { variant ->
         variant.outputs.all { output ->
-            output.outputFileName = "GodotGooglePlayBilling.${variant.name}.aar"
+            output.outputFileName = "GodotGooglePlayBilling.$pluginVersionName.${variant.name}.aar"
         }
     }
-
 }
 
 dependencies {


### PR DESCRIPTION
Closes #3 

### Problems

The resulting AAR is named `GodotGooglePlayBilling.<version>-<variant>.aar`. Do you know a quick fix to change the dash back to a dot @m4gr3d to match other `godot-lib` naming scheme? I wouldn't mind too much if that's not feasible without doing weird things in the Gradle build script.