### PR TITLE
Add original_json Dictionary key, bump to 1.1.1

### DIFF
--- a/GodotGooglePlayBilling.gdap
+++ b/GodotGooglePlayBilling.gdap
@@ -2,7 +2,7 @@
 
 name="GodotGooglePlayBilling"
 binary_type="local"
-binary="GodotGooglePlayBilling.1.1.0.release.aar"
+binary="GodotGooglePlayBilling.1.1.1.release.aar"
 
 [dependencies]
 remote=["com.android.billingclient:billing:4.0.0"]

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ You can find the docs for this first-party plugin in the [official Godot docs](h
 
 Prerequisites:
 
-- Android SDK (platform version 29)
+- Android SDK (platform version 30)
 - the Godot Android library (`godot-lib.***.release.aar`) for your version of Godot from the [downloads page](https://godotengine.org/download).
 
 Steps to build:

--- a/godot-google-play-billing/build.gradle
+++ b/godot-google-play-billing/build.gradle
@@ -2,8 +2,8 @@ plugins {
     id 'com.android.library'
 }
 
-ext.pluginVersionCode = 3
-ext.pluginVersionName = "1.1.0"
+ext.pluginVersionCode = 4
+ext.pluginVersionName = "1.1.1"
 
 android {
     compileSdkVersion 30

--- a/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/utils/GooglePlayBillingUtils.java
+++ b/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/utils/GooglePlayBillingUtils.java
@@ -41,6 +41,7 @@ import java.util.List;
 public class GooglePlayBillingUtils {
 	public static Dictionary convertPurchaseToDictionary(Purchase purchase) {
 		Dictionary dictionary = new Dictionary();
+		dictionary.put("original_json", purchase.getOriginalJson());
 		dictionary.put("order_id", purchase.getOrderId());
 		dictionary.put("package_name", purchase.getPackageName());
 		dictionary.put("purchase_state", purchase.getPurchaseState());


### PR DESCRIPTION
* Per [issue 27](https://github.com/godotengine/godot-google-play-billing/issues/27) added an `original_json` key to the Purchase dictionary containing the contents of `Purchase.getOriginalJson()`.
* Bumped version to 1.1.1
* Updated readme to note that is now building against API 30.