### PR TITLE
Fix resume signal exception bug, missing methods

### DIFF
--- a/GodotGooglePlayBilling.gdap
+++ b/GodotGooglePlayBilling.gdap
@@ -2,7 +2,7 @@
 
 name="GodotGooglePlayBilling"
 binary_type="local"
-binary="GodotGooglePlayBilling.1.1.1.release.aar"
+binary="GodotGooglePlayBilling.1.1.2.release.aar"
 
 [dependencies]
 remote=["com.android.billingclient:billing:4.0.0"]

--- a/godot-google-play-billing/build.gradle
+++ b/godot-google-play-billing/build.gradle
@@ -3,7 +3,7 @@ plugins {
 }
 
 ext.pluginVersionCode = 4
-ext.pluginVersionName = "1.1.1"
+ext.pluginVersionName = "1.1.2"
 
 android {
     compileSdkVersion 30

--- a/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/GodotGooglePlayBilling.java
+++ b/godot-google-play-billing/src/main/java/org/godotengine/godot/plugin/googleplaybilling/GodotGooglePlayBilling.java
@@ -66,6 +66,7 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 
 	private final BillingClient billingClient;
 	private final HashMap<String, SkuDetails> skuDetailsCache = new HashMap<>(); // sku → SkuDetails
+	private boolean calledStartConnection;
 	private String obfuscatedAccountId;
 	private String obfuscatedProfileId;
 
@@ -77,11 +78,13 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 								.enablePendingPurchases()
 								.setListener(this)
 								.build();
+		calledStartConnection = false;
 		obfuscatedAccountId = "";
 		obfuscatedProfileId = "";
 	}
 
 	public void startConnection() {
+		calledStartConnection = true;
 		billingClient.startConnection(this);
 	}
 
@@ -280,7 +283,9 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 
 	@Override
 	public void onMainResume() {
-		emitSignal("billing_resume");
+		if (calledStartConnection) {
+			emitSignal("billing_resume");
+		}
 	}
 
 	@NonNull
@@ -292,7 +297,7 @@ public class GodotGooglePlayBilling extends GodotPlugin implements PurchasesUpda
 	@NonNull
 	@Override
 	public List<String> getPluginMethods() {
-		return Arrays.asList("startConnection", "endConnection", "confirmPriceChange", "purchase", "updateSubscription", "querySkuDetails", "isReady", "getConnectionState", "queryPurchases", "acknowledgePurchase", "consumePurchase");
+		return Arrays.asList("startConnection", "endConnection", "confirmPriceChange", "purchase", "updateSubscription", "querySkuDetails", "isReady", "getConnectionState", "queryPurchases", "acknowledgePurchase", "consumePurchase", "setObfuscatedAccountId", "setObfuscatedProfileId");
 	}
 
 	@NonNull


### PR DESCRIPTION
* The `billing_resume` signal could be triggered before the plugin
registration was complete throwing an exception, fix to not send it 
unless the connect function has been called
* Fix `setObfuscatedAccountId` and `setObfuscatedProfileId`
missing from the list returned by `getPluginMethods`
* Bump version to 1.1.2

NOTE: The latest version available in Releases is still 1.0.1. Unfortunately, it doesn't appear possible to update this via a PR, it needs to be done by a maintainer.